### PR TITLE
Added mode statistic and tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ DataFrames = "0.17,0.18,0.19,0.20"
 RecipesBase = "0.4,0.5,0.6,0.7,0.8"
 Reexport = "0.2"
 julia = "1"
+StatsBase = "0.32,0.31,0.30,0.29,0.28"
 
 [extras]
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 DataFrames = "0.17,0.18,0.19,0.20"

--- a/docs/src/background/estimators.md
+++ b/docs/src/background/estimators.md
@@ -6,6 +6,8 @@ All of these estimators are subtypes of [`Background.BackgroundEstimator`](@ref)
 
 ```@docs
 Mean
+Median
+Mode
 ```
 
 ## API/Reference

--- a/src/Background/Background.jl
+++ b/src/Background/Background.jl
@@ -2,7 +2,8 @@ module Background
 
 export estimate_background,
        Mean,
-       Median
+       Median,
+       Mode
 
 
 # Abstract types
@@ -17,7 +18,7 @@ abstract type BackgroundEstimator end
 """
     estimate_background(::BackgroundEstimator, data; dims=:)
 
-Perform 2D background estimation using the given estimator. 
+Perform 2D background estimation using the given estimator.
 
 The value returned will be an two arrays corresponding to the estimated background, whose dimensionality will depend on the `dims` keyword and the estimator used.
 

--- a/src/Background/stat_estimators.jl
+++ b/src/Background/stat_estimators.jl
@@ -28,7 +28,7 @@ This estimator returns the median of the input.
 
 # Example
 ```jldoctest
-julia> data = ones(5 ,5)
+julia> data = ones(5 ,5);
 
 julia> estimate_background(Median, data)
 1.0
@@ -46,6 +46,8 @@ estimate_background(::Median, data; dims = :) = median(data, dims = dims)
     Mode <: BackgroundEstimator
 
 This estimator returns the mode of the input.
+!!! note
+    `Mode` does not supports the dims keyword.
 
 # Example
 ```jldoctest

--- a/src/Background/stat_estimators.jl
+++ b/src/Background/stat_estimators.jl
@@ -1,4 +1,4 @@
-using Statistics
+using Statistics, StatsBase
 
 """
     Mean <: BackgroundEstimator
@@ -41,3 +41,20 @@ julia> estimate_background(Median, data, dims=1)
 struct Median <: BackgroundEstimator end
 
 estimate_background(::Median, data; dims = :) = median(data, dims = dims)
+
+"""
+    Mode <: BackgroundEstimator
+
+This estimator returns the mode of the input.
+
+# Example
+```jldoctest
+julia> data = ones(5, 5);
+
+julia> estimate_background(Mode, data)
+1.0
+```
+"""
+struct Mode <: BackgroundEstimator end
+
+estimate_background(::Mode, data; dims = :) = mode(data)

--- a/test/background/simple.jl
+++ b/test/background/simple.jl
@@ -19,3 +19,9 @@ end
     test_ones(E)
     test_zeros(E)
 end
+
+@testset "mode" begin
+    x = [1,2,3,4,5,6,5,4,3,4,34,3,43,43,3,3,3,3,1]
+    @test estimate_background(Mode, x) == 3
+    @test estimate_background(Mode, x) == estimate_background(Mode(), x)
+end


### PR DESCRIPTION
Added mode for background estimation, as was mentioned in issue #12. 
The empirical version of mode being `mode = 3median - 2mean` has not been used here, because it delivers well in symmetrical and slightly skewed distributions but gives wrong results in skewed scenarios.
Therefore the standard implementation of `mode` is used form `StatsBase.jl`