### PR TITLE
Minor doc and test restructuring

### DIFF
--- a/src/Background/estimators.jl
+++ b/src/Background/estimators.jl
@@ -79,6 +79,8 @@ julia> estimate_background(SourceExtractor, data)
 1.0
 
 julia> estimate_background(SourceExtractor, data, dims=1)
+1×5 Array{Float64,2}:
+ 1.0  1.0  1.0  1.0  1.0
 ```
 """
 struct SourceExtractor <: BackgroundEstimator end

--- a/src/Background/estimators.jl
+++ b/src/Background/estimators.jl
@@ -111,7 +111,7 @@ This estimator assumes that contaminated sky pixel values overwhelmingly display
 ```jldoctest
 julia> x = ones(5,5);
 
-julia> estimate_background(MMMBackground(), x)
+julia> estimate_background(MMMBackground, x)
 1.0
 
 julia> estimate_background(MMMBackground(4,3), x, dims = 1)

--- a/test/background/simple.jl
+++ b/test/background/simple.jl
@@ -14,10 +14,8 @@ function test_zeros(estimator)
     @test estimate_background(estimator, data, dims = 2) ≈ zeros(10)
 end
 
-@testset "$E"  for E in [Mean, Median, MMMBackground(), SourceExtractor]
-    if E != MMMBackground()
-        @test estimate_background(E, ones(10, 10)) == estimate_background(E(), ones(10, 10))
-    end
+@testset "$E"  for E in [Mean, Median, MMMBackground, SourceExtractor]
+    @test estimate_background(E, ones(10, 10)) == estimate_background(E(), ones(10, 10))
     test_ones(E)
     test_zeros(E)
 end


### PR DESCRIPTION
This is a minor doc and test fix for MMMBackground method and fixed breaking doctest for Source Extractor.