### PR TITLE
Photometry Type Stability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 /docs/build/
 Manifest.toml
+.vscode

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Photometry"
 uuid = "af68cb61-81ac-52ed-8703-edc140936be4"
 authors = ["Miles Lucas <mdlucas@hawaii.edu>"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/src/aperture/overlap.jl
+++ b/src/aperture/overlap.jl
@@ -531,9 +531,7 @@ function rectangular_overlap_single_subpixel(x0, y0, x1, y1, w, h, θ, subpixels
         y = y0 - 0.5dy
         for j in 1:subpixels
             y += dy
-            if intersects_rectangle(x, y, w, h, θ)
-                frac += 1
-            end
+            frac += inside_rectangle(x, y, w, h, θ) ? 1 : 0
         end
     end
 
@@ -543,7 +541,7 @@ end
 
 # see https://math.stackexchange.com/questions/69099/equation-of-a-rectangle
 """intersection with rectangular using implicit Lamé curve"""
-function intersects_rectangle(x, y, w, h, θ)
+function inside_rectangle(x, y, w, h, θ)
     # transform into frame of rectangle
     sinth, costh = sincos(deg2rad(-θ))
     u = x * costh - y * sinth

--- a/src/aperture/overlap.jl
+++ b/src/aperture/overlap.jl
@@ -79,7 +79,8 @@ end
 
 """Area of overlap between a rectangle and a circle"""
 function circular_overlap_single_exact(xmin, ymin, xmax, ymax, r)
-    r ≤ 0 && return 0
+    R = float(typeof(xmin))
+    r ≤ 0 && return zero(R)
     if 0 ≤ xmin
         0 ≤ ymin && return circular_overlap_core(xmin, ymin, xmax, ymax, r)
         0 ≥ ymax && return circular_overlap_core(-ymax, xmin, -ymin, xmax, r)
@@ -104,35 +105,38 @@ end
 
 """Core of circular overlap routine"""
 function circular_overlap_core(xmin, ymin, xmax, ymax, r)
-    xmin^2 + ymin^2 > r^2 && return 0
-    xmax^2 + ymax^2 < r^2 && return (xmax - xmin) * (ymax - ymin)
+    R = float(typeof(xmin))
+    xmin^2 + ymin^2 > r^2 && return zero(R)
+    xmax^2 + ymax^2 < r^2 && return R((xmax - xmin) * (ymax - ymin))
 
     d1 = sqrt(xmax^2 + ymin^2)
     d2 = sqrt(xmin^2 + ymax^2)
     if d1 < r && d2 < r
         x1, y1 = sqrt(r^2 - ymax^2), ymax
         x2, y2 = xmax, sqrt(r^2 - xmax^2)
-        return ((xmax - xmin) * (ymax - ymin) -
+        area = ((xmax - xmin) * (ymax - ymin) -
                 area_triangle(x1, y1, x2, y2, xmax, ymax) +
                 area_arc(x1, y1, x2, y2, r))
     elseif d1 < r
         x1, y1 = xmin, sqrt(r^2 - xmin^2)
         x2, y2 = xmax, sqrt(r^2 - xmax^2)
-        return (area_arc(x1, y1, x2, y2, r) +
+        area = (area_arc(x1, y1, x2, y2, r) +
                 area_triangle(x1, y1, x1, ymin, xmax, ymin) +
                 area_triangle(x1, y1, x2, ymin, x2, y2))
     elseif d2 < r
         x1, y1 = sqrt(r^2 - ymin^2), ymin
         x2, y2 = sqrt(r^2 - ymax^2), ymax
-        return (area_arc(x1, y1, x2, y2, r) +
+        area = (area_arc(x1, y1, x2, y2, r) +
                 area_triangle(x1, y1, xmin, y1, xmin, ymax) +
                 area_triangle(x1, y1, xmin, y2, x2, y2))
     else
         x1, y1 = sqrt(r^2 - ymin^2), ymin
         x2, y2 = xmin, sqrt(r^2 - xmin^2)
-        return (area_arc(x1, y1, x2, y2, r) +
+        area = (area_arc(x1, y1, x2, y2, r) +
                 area_triangle(x1, y1, x2, y2, xmin, ymin))
     end
+
+    return R(area)
 end
 
 ####################################
@@ -150,7 +154,7 @@ Area of a circular segment above a chord between two points with circle radius `
 function area_arc(x0, y0, x1, y1, r)
     a = sqrt((x1 - x0)^2 + (y1 - y0)^2)
     θ = 2asin(0.5a / r)
-    return 0.5r^2 * (θ - sin(θ))
+    return r^2 * (θ - sin(θ)) / 2
 end
 
 # is (x, y) contained within triangle specified by three points.
@@ -185,7 +189,8 @@ General equation of ellipse:
 inside_ellipse(x, y, h, k, cxx, cyy, cxy) = cxx * (x - h)^2 + cxy * (x - h) * (y - k) + cyy * (y - k)^2  - 1 < 0
 
 function elliptical_overlap(xmin, xmax, ymin, ymax, nx, ny, a, b, theta; method = :exact)
-    out = fill(0.0, ny, nx)
+    R = float(typeof(xmin))
+    out = fill(zero(R), ny, nx)
 
     # width of each element
     dx = (xmax - xmin) / nx

--- a/src/aperture/overlap.jl
+++ b/src/aperture/overlap.jl
@@ -480,7 +480,8 @@ end
 # Rectangular routines
 
 function rectangular_overlap(xmin, xmax, ymin, ymax, nx, ny, w, h, θ; method = :exact)
-    out = fill(0.0, ny, nx)
+    R = float(typeof(xmin))
+    out = fill(zero(R), ny, nx)
 
     # width of each element
     dx = (xmax - xmin) / nx

--- a/test/aperture/overlap.jl
+++ b/test/aperture/overlap.jl
@@ -64,6 +64,16 @@ using Photometry.Aperture: circular_overlap,
 
     end
 
+    @testset "type stability" begin
+        for grid_size in [50, 500, 1000], circ_size in (0.2, 0.4, 0.8), method in [:exact, :center, (:subpixel, 2), (:subpixel, 5), (:subpixel, 10)]
+            @inferred circular_overlap(-1, -1, 1, 1, grid_size, grid_size, circ_size, method = method)
+        end
+        r = 5
+        @inferred circular_overlap_core(0, 0, r, r, r)
+        @inferred circular_overlap_single_exact(0, 0, r, r, r)
+        @inferred circular_overlap_single_subpixel(0, 0, 20, 20, 15, 5)
+    end
+
 end # circles
 
 @testset "overlap - elliptical" begin

--- a/test/aperture/overlap.jl
+++ b/test/aperture/overlap.jl
@@ -173,4 +173,17 @@ end # overlap rectangular
         @test area_arc(0, r, r, 0, r) ≈ r^2 / 2 * (π / 2 - 1)
     end
 
+    @testset "inside ellipse" begin
+        @test inside_ellipse(0, 0, 0, 0, 1, 1, 1)
+        @test !inside_ellipse(10, 10, 5, 5, 1, 1, 1)
+    end
+
+
+    @testset "type stability" begin
+        @inferred area_arc(0, 0, 0, 0, 10)
+        @inferred area_triangle(0, 0, 1, 0, 0, 1)
+        @inferred inside_triangle(0, 0, 0, 0, 0, 1, 1, 0)
+        @inferred inside_ellipse(0, 0, 5, 5, 1, 1, 1)
+    end
+
 end # overlap utils

--- a/test/aperture/overlap.jl
+++ b/test/aperture/overlap.jl
@@ -6,6 +6,7 @@ using Photometry.Aperture: circular_overlap,
                            area_triangle,
                            inside_ellipse,
                            inside_triangle,
+                           inside_rectangle,
                            circle_line,
                            circle_segment,
                            circle_segment_single2,
@@ -178,12 +179,17 @@ end # overlap rectangular
         @test !inside_ellipse(10, 10, 5, 5, 1, 1, 1)
     end
 
+    @testset "inside rectangle" begin
+        @test inside_rectangle(0, 0, 3, 4, 0)
+        @test !inside_rectangle(10, 10, 3, 4, 0)
+    end
 
     @testset "type stability" begin
         @inferred area_arc(0, 0, 0, 0, 10)
         @inferred area_triangle(0, 0, 1, 0, 0, 1)
         @inferred inside_triangle(0, 0, 0, 0, 0, 1, 1, 0)
         @inferred inside_ellipse(0, 0, 5, 5, 1, 1, 1)
+        @inferred inside_rectangle(0, 0, 3, 4, 0)
     end
 
 end # overlap utils

--- a/test/aperture/overlap.jl
+++ b/test/aperture/overlap.jl
@@ -150,6 +150,15 @@ end # overlap elliptical
     @testset "exact" begin
         @test rectangular_overlap_exact(0, 0, 1, 1, 1, 1, 0) ≈ 0.25
     end
+
+    @testset "type stability" begin
+        for grid_size in [50, 500, 1000], w in (0.2, 0.4, 0.8), method in [:exact, :center, (:subpixel, 2), (:subpixel, 5), (:subpixel, 10)]
+            method === :exact && continue  # TODO area in LazySets.jl not type stable
+            @inferred rectangular_overlap(-1, -1, 1, 1, grid_size, grid_size, w, w, 0, method = method)
+        end
+        # @inferred rectangular_overlap_exact(0, 0, 1, 1, 2, 2, 0) # TODO area in LazySets.jl not type stable
+        @inferred rectangular_overlap_single_subpixel(0, 0, 1, 1, 2, 2, 0, 5)
+    end
 end # overlap rectangular
 
 @testset "overlap - utils" begin

--- a/test/aperture/overlap.jl
+++ b/test/aperture/overlap.jl
@@ -79,12 +79,6 @@ end # circles
 
 @testset "overlap - elliptical" begin
 
-    @testset "position with respect to ellipse" begin
-        @test !inside_ellipse(5, 3, 0, 0, 1 / 16, 1 / 32, 0)
-        @test inside_ellipse(0, 0, 0, 0, 5, 6.2, 0)
-        @test inside_ellipse(1, 2, 0, 0, 1 / 37, 1 / 36, -1 / 80)
-    end
-
     @testset "elliptical overlap" for grid_size in [50, 500, 1000], ellipse_size in ([0.2,0.2,0], [0.4, 0.4, 0], [0.8, 0.8, 0]), method in [:center, (:subpixel, 2), (:subpixel, 5), (:subpixel, 10)]
 
         g = elliptical_overlap(-1, -1, 1, 1, grid_size, grid_size, ellipse_size, method = method)
@@ -144,6 +138,11 @@ end # circles
         @test elliptical_overlap_exact(0, 2, 1, 3, 3.0, 3.0, 0) ≈ 0.943480 atol = 1e-6
     end
 
+    @testset "type stability" begin
+        for grid_size in [50, 500, 1000], ellipse_size in ([0.2,0.2,0], [0.4, 0.4, 0], [0.8, 0.8, 0]), method in [:center, (:subpixel, 2), (:subpixel, 5), (:subpixel, 10)]
+            @inferred elliptical_overlap(-1, -1, 1, 1, grid_size, grid_size, ellipse_size, method = method)
+        end
+    end
 end # overlap elliptical
 
 @testset "overlap - rectangular" begin
@@ -186,6 +185,9 @@ end # overlap rectangular
     @testset "inside ellipse" begin
         @test inside_ellipse(0, 0, 0, 0, 1, 1, 1)
         @test !inside_ellipse(10, 10, 5, 5, 1, 1, 1)
+        @test !inside_ellipse(5, 3, 0, 0, 1 / 16, 1 / 32, 0)
+        @test inside_ellipse(0, 0, 0, 0, 5, 6.2, 0)
+        @test inside_ellipse(1, 2, 0, 0, 1 / 37, 1 / 36, -1 / 80)
     end
 
     @testset "inside rectangle" begin

--- a/test/aperture/photometry.jl
+++ b/test/aperture/photometry.jl
@@ -25,7 +25,6 @@ area(ap::EllipticalAnnulus) = π * ap.a_out * ap.b_out - π * ap.a_in * ap.b_in
 area(ap::RectangularAperture) = ap.w * ap.h
 area(ap::RectangularAnnulus) = ap.w_out * ap.h_out - ap.w_in * ap.h_in
 
-
 @testset "outside - $AP" for (AP, params) in zip(APERTURES, PARAMS)
     data = ones(10, 10)
     aperture = AP(-60, 60, params...)
@@ -61,6 +60,15 @@ end
     @test table_sub.aperture_sum ≈ table_ex.aperture_sum atol = 0.1
     @test table_cent.aperture_sum ≤ table_ex.aperture_sum
 
+end
+
+@testset "type stability - $AP" for (AP, params) in zip(APERTURES, PARAMS)
+    data = zeros(40, 40)
+    aperture = AP(20.0, 20.0, params...)
+
+    @inferred aperture_photometry(aperture, data, method = :center)
+    @inferred aperture_photometry(aperture, data, method = (:subpixel, 10))
+    @inferred aperture_photometry(aperture, data, method = :exact)
 end
 
 @testset "photometry - circular" begin


### PR DESCRIPTION
Gets as much of the functionality in the aperture photometry code to be type stable. Everything is type-stable except for rectangular apertures in `:exact` mode, because the underlying LazySets code is not type-stable. 

This should open and make it easy to add some benchmarks for the photometry.