### PR TITLE
CompatHelper: bump compat for "DataFrames" to "0.21"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-DataFrames = "0.17,0.18,0.19,0.20"
+DataFrames = "0.17,0.18,0.19,0.20, 0.21"
 ImageFiltering = "0.6"
 ImageTransformations = "0.8"
 Interpolations = "0.12"


### PR DESCRIPTION
This pull request changes the compat entry for the `DataFrames` package from `0.17,0.18,0.19,0.20` to `0.17,0.18,0.19,0.20, 0.21`.

This keeps the compat entries for earlier versions.

Note: I have not tested your package with this new compat entry. It is your responsibility to make sure that your package tests pass before you merge this pull request.